### PR TITLE
Center map to be Montreal city

### DIFF
--- a/ckanext/spatial/public/js/common_map.js
+++ b/ckanext/spatial/public/js/common_map.js
@@ -86,6 +86,11 @@
       }
 
       map.addLayer(baseLayer);
+    
+      // Center the map to be Montreal city
+      setTimeout(() => {
+        map.setView(new L.LatLng(45.577023,-73.7785046), 9);
+      }, 0);
 
       return map;
 


### PR DESCRIPTION
This PR will center the map shown in the sidebar in the Datasets page to be Montreal city, instead of the entire world.